### PR TITLE
Adding detecting circular dependecies

### DIFF
--- a/lib/PhpactorContainer.php
+++ b/lib/PhpactorContainer.php
@@ -31,6 +31,11 @@ class PhpactorContainer implements Container, ContainerBuilder
     private $services = [];
 
     /**
+     * @var array<string>
+     */
+    private array $servicesToResolve = [];
+
+    /**
      * @param array<string,mixed> $parameters
      */
     public function __construct(array $parameters = [])
@@ -80,7 +85,18 @@ class PhpactorContainer implements Container, ContainerBuilder
             ));
         }
 
+        if (in_array($id, $this->servicesToResolve)) {
+            throw new RuntimeException(sprintf(
+                'Circular dependency detected: %s->%s',
+                implode('->', $this->servicesToResolve),
+                $id
+            ));
+        }
+        $this->servicesToResolve[] = $id;
+
         $this->services[$id] = $this->factories[$id]($this);
+
+        $this->servicesToResolve = [];
 
         return $this->services[$id];
     }

--- a/tests/Unit/PhpactorContainerTest.php
+++ b/tests/Unit/PhpactorContainerTest.php
@@ -62,6 +62,18 @@ class PhpactorContainerTest extends TestCase
         $this->container->get('foobar');
     }
 
+    public function testThrowsExceptionForCircularDependency(): void
+    {
+        $this->container->register('foobar', function (Container $container) {
+            $container->get('foobar');
+        });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Circular dependency detected: foobar->foobar');
+
+        $this->container->get('foobar');
+    }
+
     public function testRetrievesService(): void
     {
         $this->container->register('foobar', function (Container $container) {


### PR DESCRIPTION
When a service has a dependency on another service in the same chain, this will silently fail and run out of memory. This adds an exception if a service has a dependency on itself.